### PR TITLE
Reduce duplicated logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 /npm-debug.log
+
+test
+.vscode

--- a/bin/directoryUtil.js
+++ b/bin/directoryUtil.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+
+const LOCATION_LOCAL = '/usr/local/lib/node_modules/archgen/bin/archetypes/';
+const LOCATION_LIB = '/usr/lib/node_modules/archgen/bin/archetypes/';
+
+module.exports = {
+  getDirectory(scriptPath, archetype) {
+    const possibleDirectories = [
+      LOCATION_LIB + archetype + '/',
+      LOCATION_LOCAL + archetype + '/',
+      scriptPath.substr(0, scriptPath.length - 13) +
+        '\\\\archetypes\\\\' +
+        archetype +
+        '\\\\'
+    ];
+
+    return getDirectoryIfExists(possibleDirectories);
+  }
+};
+
+function getDirectoryIfExists(possibleDirectories) {
+  const directoryPath = possibleDirectories[0];
+
+  // Should this be thrown here or let it be handled at the highest level?
+  if (!directoryPath) {
+    throw new Error('Unable to locate given archetype');
+  }
+
+  if (fs.existsSync(directoryPath)) {
+    return directoryPath;
+  }
+
+  return getDirectoryIfExists(possibleDirectories.slice(1));
+}

--- a/bin/fileReader.js
+++ b/bin/fileReader.js
@@ -78,11 +78,11 @@ function evaluateFileLines(fileLines) {
 }
 
 function processLines(fileLines, i) {
-  if (fileLines[i] == '<_forEntity_>') {
+  if (fileLines[i] === '<_forEntity_>') {
     let j = parseInt(i) + 1;
     let foundEnd = false;
     while (!foundEnd) {
-      if (fileLines[j] == '<_endForEntity_>') {
+      if (fileLines[j] === '<_endForEntity_>') {
         foundEnd = true;
       }
       j++;

--- a/bin/fileReader.js
+++ b/bin/fileReader.js
@@ -1,209 +1,203 @@
-#! /usr/bin/env node 
+#! /usr/bin/env node
 const fs = require('file-system');
 const parser = require('./parser');
 const stringUtil = require('./stringUtil');
+const { getDirectory } = require('./directoryUtil');
 
 const fileDirectories = [];
-let descriptor;
 const outFiles = [];
 const tagEx = /<_(\w*)_>/;
 const propEx = /<_prop\.([\w|:]*)_>/;
 const entityEx = /<_entity\.([\w|:]*)_>/;
-let dir;
 
-if (fs.existsSync(process.argv[1].substr(0, process.argv[1].length - 13) + '\\\\archetypes\\\\' + process.argv[2] + '\\\\')) {
-  dir = process.argv[1].substr(0, process.argv[1].length - 13) + '\\\\archetypes\\\\' + process.argv[2] + '\\\\';
-}
-else if (fs.existsSync('/usr/lib/node_modules/archgen/bin/archetypes/' + process.argv[2] + '/')) {
-  dir = '/usr/lib/node_modules/archgen/bin/archetypes/' + process.argv[2] + '/';
-}
-else if (fs.existsSync('/usr/local/lib/node_modules/archgen/bin/archetypes/' + process.argv[2] + '/')) {
-  dir = '/usr/local/lib/node_modules/archgen/bin/archetypes/' + process.argv[2] + '/';
-}
-
-
+const DESCRIPTOR_PATH = './descriptor.json';
 
 //check if user entered argument
-if(process.argv[2] === 'install' || process.argv[2] === 'default') {
+if (process.argv[2] === 'install' || process.argv[2] === 'default') {
   require('./options')[process.argv[2]]();
-} else {
-  fs.readdir('./', (err, files) => {
-    files.forEach(file => {
-      if(file == 'descriptor.json') {
-        descriptor = JSON.parse(fs.readFileSync(file, 'utf8'));
-      }
-    });
-  });
+  return;
+}
 
-  fs.readdir(dir, (err, files) => {
-    files.forEach(file => {
-      if(file.includes('.txt')) {
-        file = dir + file;
-        const curFile = fs.readFileSync(file, 'utf8');
-        const fileLines = parser.splitByLine(curFile);
+if (!fs.existsSync(DESCRIPTOR_PATH)) {
+  throw new Error('Cannot find descriptor.json');
+}
 
-        if(fileLines[0] === '<_forEntity_>') {
-          for(let entity of descriptor.entities) {
-            outFiles.push(evaluateFileLines(evaluateForEntity(fileLines.slice(1, fileLines.length), entity)));
-          }
-        } else {
+let descriptor;
 
-          fileDirectories.push(evaluateForPath(fileLines[0]));
-          outFiles.push(evaluateFileLines(fileLines.slice(1, fileLines.length)));
+try {
+  descriptor = JSON.parse(fs.readFileSync(DESCRIPTOR_PATH, 'utf8'));
+} catch (e) {
+  // TODO: Handle json parse errors
+  throw e;
+}
+
+const dir = getDirectory(process.argv[1], process.argv[2]);
+
+fs.readdir(dir, (err, files) => {
+  files.forEach(file => {
+    if (file.includes('.txt')) {
+      file = dir + file;
+      const curFile = fs.readFileSync(file, 'utf8');
+      const fileLines = parser.splitByLine(curFile);
+
+      if (fileLines[0] === '<_forEntity_>') {
+        for (let entity of descriptor.entities) {
+          outFiles.push(
+            evaluateFileLines(
+              evaluateForEntity(fileLines.slice(1, fileLines.length), entity)
+            )
+          );
         }
+      } else {
+        fileDirectories.push(evaluateForPath(fileLines[0]));
+        outFiles.push(evaluateFileLines(fileLines.slice(1, fileLines.length)));
       }
-
-    });
-    for(let i in outFiles) {
-      outFiles[i] = parser.buildFileFromArray(outFiles[i]);
-      console.log('Printing File: ' + fileDirectories[i]);
-      console.log('---------------------------------------');
-      console.log(outFiles[i]);
-      fs.writeFileSync(fileDirectories[i], outFiles[i]);
     }
   });
 
-  function evaluateForPath(path) {
-    const directory = [];
-    directory.push(path);
-    return evaluateFileLines(directory)[0];
+  for (let i in outFiles) {
+    outFiles[i] = parser.buildFileFromArray(outFiles[i]);
+    console.log('Printing File: ' + fileDirectories[i]);
+    console.log('---------------------------------------');
+    console.log(outFiles[i]);
+    fs.writeFileSync(fileDirectories[i], outFiles[i]);
   }
+});
 
-  function evaluateFileLines(fileLines) {
-    for(let i in fileLines) {
-      processLines(fileLines, i);
+function evaluateForPath(path) {
+  const directory = [];
+  directory.push(path);
+  return evaluateFileLines(directory)[0];
+}
+
+function evaluateFileLines(fileLines) {
+  for (let i in fileLines) {
+    processLines(fileLines, i);
+  }
+  return fileLines;
+}
+
+function processLines(fileLines, i) {
+  if (fileLines[i] == '<_forEntity_>') {
+    let j = parseInt(i) + 1;
+    let foundEnd = false;
+    while (!foundEnd) {
+      if (fileLines[j] == '<_endForEntity_>') {
+        foundEnd = true;
+      }
+      j++;
     }
-    return fileLines;
+    const entityBlock = fileLines.splice(i, j - i);
+    entityBlock.pop();
+    entityBlock.shift();
+    for (let entity of descriptor.entities) {
+      insertMultipleElementsIntoArray(
+        fileLines,
+        i,
+        evaluateTemplateVariable(shallowCopy(entityBlock), entity, 'entity')
+      );
+    }
   }
+  while ((variable = tagEx.exec(fileLines[i]))) {
+    if (variable) {
+      text = variable[1];
+      index = variable.index;
+      fileLines[i] =
+        fileLines[i].substr(0, index) +
+        descriptor[text] +
+        fileLines[i].substr(index + text.length + 4);
+    }
+  }
+}
 
-  function processLines(fileLines, i) {
-    if(fileLines[i] == '<_forEntity_>') {
+function evaluateForEntity(fileLines, entity) {
+  fileLines = shallowCopy(fileLines);
+  for (let i = 0; i < fileLines.length; i++) {
+    if (fileLines[i] == '<_forProp_>') {
       let j = parseInt(i) + 1;
       let foundEnd = false;
-      while(!foundEnd) {
-        if(fileLines[j] == '<_endForEntity_>') {
+      while (!foundEnd) {
+        if (fileLines[j] == '<_endForProp_>') {
           foundEnd = true;
         }
         j++;
       }
-      const entityBlock = fileLines.splice(i, j - i);
-      entityBlock.pop();
-      entityBlock.shift();
-      for(let entity of descriptor.entities) {
-        insertMultipleElementsIntoArray(fileLines, i, evaluateForEntityLoop(shallowCopy(entityBlock), entity));
+      const propBlock = fileLines.splice(i, j - i);
+      propBlock.pop();
+      propBlock.shift();
+      for (let prop of entity.props) {
+        insertMultipleElementsIntoArray(
+          fileLines,
+          i,
+          evaluateTemplateVariable(shallowCopy(propBlock), prop, 'prop')
+        );
       }
     }
-    while(variable = tagEx.exec(fileLines[i])) {
-      if(variable) {
-        text = variable[1];
+  }
+  filesLines = evaluateTemplateVariable(fileLines, entity, 'entity');
+  fileDirectories.push(evaluateForPath(fileLines[0]));
+  fileLines.shift();
+  return fileLines;
+}
+
+function insertMultipleElementsIntoArray(array, index, arrayToInsert) {
+  for (let element of arrayToInsert) {
+    array.splice(index++, 0, element);
+  }
+}
+
+function shallowCopy(array) {
+  return array.slice();
+}
+
+function evaluateTemplateVariable(fileLines, section, sectionType) {
+  const sectionRegEx = getSectionRegEx(sectionType);
+  for (let i in fileLines) {
+    while ((variable = sectionRegEx.exec(fileLines[i]))) {
+      if (variable) {
+        let text = variable[1];
+        const textLength = text.length;
+        let split;
+        let modText = text;
+        if (text.includes(':')) {
+          split = parser.splitByColon(text);
+          text = split[0];
+          modText = stringUtil[split[1]](section[split[0]]);
+        } else {
+          modText = section[text];
+        }
         index = variable.index;
-        fileLines[i] = fileLines[i].substr(0, index) + descriptor[text] + fileLines[i].substr(index + text.length + 4);
+
+        const offset = getSectionOffset(sectionType);
+
+        fileLines[i] =
+          fileLines[i].substr(0, index) +
+          modText +
+          fileLines[i].substr(index + textLength + offset);
       }
     }
   }
+  return fileLines;
+}
 
-  function evaluateForEntity(fileLines, entity) {
-    fileLines = shallowCopy(fileLines);
-    for(let i = 0; i < fileLines.length; i++) {
-
-      if(fileLines[i] == '<_forProp_>') {
-        let j = parseInt(i) + 1;
-        let foundEnd = false;
-        while(!foundEnd) {
-          if(fileLines[j] == '<_endForProp_>') {
-            foundEnd = true;
-          }
-          j++;
-        }
-        const propBlock = fileLines.splice(i, j - i);
-        propBlock.pop();
-        propBlock.shift();
-        for(let prop of entity.props) {
-          insertMultipleElementsIntoArray(fileLines, i, evaluateForProps(shallowCopy(propBlock), prop));
-        }
-      }
-      while(variable = entityEx.exec(fileLines[i])) {
-
-        if(variable) {
-          let text = variable[1];
-          const textLength = text.length;
-          let split;
-          let modText = text;
-          if(text.includes(':')) {
-            split = parser.splitByColon(text);
-            text = split[0];
-            modText = stringUtil[split[1]](entity[split[0]]);
-          } else {
-            modText = entity[text];
-          }
-          index = variable.index;
-          fileLines[i] = fileLines[i].substr(0, index) + modText + fileLines[i].substr(index + textLength + 11);
-        }
-
-      }
-
-    }
-    fileDirectories.push(evaluateForPath(fileLines[0]));
-    fileLines.shift();
-    return fileLines;
+function getSectionRegEx(sectionType) {
+  switch (sectionType) {
+    case 'entity':
+      return entityEx;
+    case 'prop':
+      return propEx;
+    case 'tag':
+    default:
+      return tagEx;
   }
+}
 
-  function insertMultipleElementsIntoArray(array, index, arrayToInsert) {
-    for(let element of arrayToInsert) {
-      array.splice(index++, 0, element);
-    }
+function getSectionOffset(sectionType) {
+  switch (sectionType) {
+    case 'entity':
+      return 11;
+    case 'prop':
+    default:
+      return 9;
   }
-
-  function shallowCopy(array) {
-    return array.slice();
-  }
-
-  function evaluateForEntityLoop(fileLines, entity) {
-    for(let i in fileLines) {
-      while(variable = entityEx.exec(fileLines[i])) {
-
-        if(variable) {
-          let text = variable[1];
-          const textLength = text.length;
-          let split;
-          let modText = text;
-          if(text.includes(':')) {
-            split = parser.splitByColon(text);
-            text = split[0];
-            modText = stringUtil[split[1]](entity[split[0]]);
-          } else {
-            modText = entity[text];
-          }
-          index = variable.index;
-          fileLines[i] = fileLines[i].substr(0, index) + modText + fileLines[i].substr(index + textLength + 11);
-        }
-      }
-    }
-    return fileLines;
-  }
-
-  function evaluateForProps(fileLines, prop) {
-    for(let i in fileLines) {
-      while(variable = propEx.exec(fileLines[i])) {
-
-        if(variable) {
-          let text = variable[1];
-          const textLength = text.length;
-          let split;
-          let modText = text;
-          if(text.includes(':')) {
-            split = parser.splitByColon(text);
-            text = split[0];
-            modText = stringUtil[split[1]](prop[split[0]]);
-          } else {
-            modText = prop[text];
-          }
-          index = variable.index;
-          fileLines[i] = fileLines[i].substr(0, index) + modText + fileLines[i].substr(index + textLength + 9);
-        }
-      }
-    }
-    return fileLines;
-  }
-
 }

--- a/bin/fileReader.js
+++ b/bin/fileReader.js
@@ -1,14 +1,14 @@
 #! /usr/bin/env node 
-let fs = require('file-system');
-let parser = require('./parser');
-let stringUtil = require('./stringUtil');
+const fs = require('file-system');
+const parser = require('./parser');
+const stringUtil = require('./stringUtil');
 
-let fileDirectories = [];
+const fileDirectories = [];
 let descriptor;
-let outFiles = [];
-let tagEx = /<_(\w*)_>/;
-let propEx = /<_prop\.([\w|:]*)_>/;
-let entityEx = /<_entity\.([\w|:]*)_>/;
+const outFiles = [];
+const tagEx = /<_(\w*)_>/;
+const propEx = /<_prop\.([\w|:]*)_>/;
+const entityEx = /<_entity\.([\w|:]*)_>/;
 let dir;
 
 if (fs.existsSync(process.argv[1].substr(0, process.argv[1].length - 13) + '\\\\archetypes\\\\' + process.argv[2] + '\\\\')) {
@@ -24,7 +24,7 @@ else if (fs.existsSync('/usr/local/lib/node_modules/archgen/bin/archetypes/' + p
 
 
 //check if user entered argument
-if(process.argv[2] == 'install' || process.argv[2] == 'default') {
+if(process.argv[2] === 'install' || process.argv[2] === 'default') {
   require('./options')[process.argv[2]]();
 } else {
   fs.readdir('./', (err, files) => {
@@ -39,10 +39,10 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
     files.forEach(file => {
       if(file.includes('.txt')) {
         file = dir + file;
-        let curFile = fs.readFileSync(file, 'utf8');
-        let fileLines = parser.splitByLine(curFile);
+        const curFile = fs.readFileSync(file, 'utf8');
+        const fileLines = parser.splitByLine(curFile);
 
-        if(fileLines[0] == '<_forEntity_>') {
+        if(fileLines[0] === '<_forEntity_>') {
           for(let entity of descriptor.entities) {
             outFiles.push(evaluateFileLines(evaluateForEntity(fileLines.slice(1, fileLines.length), entity)));
           }
@@ -64,16 +64,13 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
   });
 
   function evaluateForPath(path) {
-    let directory = [];
+    const directory = [];
     directory.push(path);
     return evaluateFileLines(directory)[0];
   }
 
   function evaluateFileLines(fileLines) {
-    let result = '';
     for(let i in fileLines) {
-      let text;
-      let index;
       processLines(fileLines, i);
     }
     return fileLines;
@@ -89,7 +86,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
         }
         j++;
       }
-      let entityBlock = fileLines.splice(i, j - i);
+      const entityBlock = fileLines.splice(i, j - i);
       entityBlock.pop();
       entityBlock.shift();
       for(let entity of descriptor.entities) {
@@ -118,7 +115,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
           }
           j++;
         }
-        let propBlock = fileLines.splice(i, j - i);
+        const propBlock = fileLines.splice(i, j - i);
         propBlock.pop();
         propBlock.shift();
         for(let prop of entity.props) {
@@ -129,7 +126,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
 
         if(variable) {
           let text = variable[1];
-          let textLength = text.length;
+          const textLength = text.length;
           let split;
           let modText = text;
           if(text.includes(':')) {
@@ -158,11 +155,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
   }
 
   function shallowCopy(array) {
-    let result = [];
-    for(let i in array) {
-      result[i] = array[i];
-    }
-    return result;
+    return array.slice();
   }
 
   function evaluateForEntityLoop(fileLines, entity) {
@@ -171,7 +164,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
 
         if(variable) {
           let text = variable[1];
-          let textLength = text.length;
+          const textLength = text.length;
           let split;
           let modText = text;
           if(text.includes(':')) {
@@ -195,7 +188,7 @@ if(process.argv[2] == 'install' || process.argv[2] == 'default') {
 
         if(variable) {
           let text = variable[1];
-          let textLength = text.length;
+          const textLength = text.length;
           let split;
           let modText = text;
           if(text.includes(':')) {

--- a/bin/parser.js
+++ b/bin/parser.js
@@ -4,11 +4,7 @@ module.exports = {
   },
 
   buildFileFromArray: function(array) {
-    let result = '';
-    for(let line of array) {
-      result += line + '\n';
-    }
-    return result;
+    return array.join('\n')
   },
 
   splitByDot: function(str) {


### PR DESCRIPTION
This is a much more involved change. I've tested it only with the mean-ts archetype, but it would need your eyes on it to ensure no functionality is lost or bugs introduced.

All changed from https://github.com/NickSuwyn/archgen/pull/1 plus...

* Created a utility that handles the logic of checking for possible locations of the achetypes folder.
* Removed the race condition when setting the descriptor variable.
*  Used prettier on files to normalize line widths
* Combined functionality of evaluateForEntityLoop & evaluvateForEntityProps. The new function is called evaluateTemplateVariable and takes an extra param (sectionType) that applies the specific differences for entity and prop.
* evaluateTemplateVariable also allowed for the removal of the same logic within evaluateForEntity
